### PR TITLE
TestNet V4 upgrade docs improvements

### DIFF
--- a/upgrades/TestNet_v3-v4_upgrade.md
+++ b/upgrades/TestNet_v3-v4_upgrade.md
@@ -1,6 +1,7 @@
 # TestNet v3 to v4 Upgrade
 
-On 09/04/2020, TestNet was upgraded from **v3** to **v4**, with v4 using the latest `und` **v1.4.1** updates. The following instructions can be used to upgrade your node to the latest
+On 09/04/2020, TestNet was upgraded from **v3** to **v4**, with v4 using the latest `und` **v1.4.1** updates.
+The following instructions can be used to upgrade your node to the latest
 `und` v1.4.1+ software and v4 genesis.
 
 The v3 database was exported at height `715000` and used as the `UND-Mainchain-TestNet-v4` genesis.
@@ -16,10 +17,47 @@ assuming it is being run as a service, for example:
 sudo systemctl stop und
 ```
 
-### 2. update the `und` binary
+Or if the node is not running as a service (i.e. was started using `und start ...`,
+and terminal kept open), then for example <kbd>Ctrl</kbd>+<kbd>C</kbd>.
+
+### 2. Update the `und` binary
+
+You can check the method you originally used by running:
+
+```bash
+which und
+```
+
+If the output is `/usr/local/bin/und`, then the auto install script was _probably_ used.
+If the output is similar to `/home/username/go/bin/und`, then it was probably manually installed.
+
+#### 2.1 Auto install script
+
+If the `und` binary was installed using the auto shell script, run:
 
 ```bash
 curl -sfL https://git.io/JvHZO | sh
+```
+
+#### 2.2 Manual installation
+
+If the binary was manually installed by cloning the git repository, and using the `make install` target,
+you can either upgrade manually:
+
+```bash
+$ rm $GOPATH/bin/und
+$ rm $GOPATH/bin/undcli
+$ cd /path/to/cloned/mainchain
+$ git checkout 1.4.1
+$ make install
+```
+
+Or, delete the binaries in `$GOPATH` and use the auto-install script:
+
+```bash
+$ rm $GOPATH/bin/und
+$ rm $GOPATH/bin/undcli
+$ curl -sfL https://git.io/JvHZO | sh
 ```
 
 ### 3. check latest version
@@ -75,7 +113,11 @@ sudo apt install jq
 
 ### 7.  restart the node
 
-Restart your node an join the network:
+Restart your node an join the network.
+
+#### 7.1 `und` as a service
+
+If you have set up the node to run as a service, for example:
 
 ```bash
 sudo systemctl start und
@@ -93,5 +135,11 @@ and:
 $ sudo journalctl -u und --follow
 ```
 
-Finally, unjail your TestNet validator if necessary
+#### 7.2 manually running `und`
+
+If you are running the node manually, for example:
+
+```bash
+und start
+```
 


### PR DESCRIPTION
Add clearer instructions for manually installed instances of the `und` binaries. Closes https://github.com/unification-com/testnet/issues/20